### PR TITLE
Improvements to about org flow, statuses and workflow

### DIFF
--- a/app/assets/javascripts/modules/copy-content.js
+++ b/app/assets/javascripts/modules/copy-content.js
@@ -42,8 +42,8 @@
             field.val(newValue);
             copied.push(field.parents('.form-group').find('label').text());
 
-            var $codemirror = field.nextAll('.CodeMirror')[0].CodeMirror;
-            $codemirror.getDoc().setValue(newValue);
+            // var $codemirror = field.nextAll('.CodeMirror')[0].CodeMirror;
+            // $codemirror.getDoc().setValue(newValue);
           }
         });
 

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -84,17 +84,6 @@ table thead th {
   background-color: $grey-4;
   padding: 20px;
   border-top: 5px solid $govuk-blue;
-
-  .unpublished-changes {
-    background: $govuk-blue;
-    color: $white;
-    margin: -20px -20px 30px;
-    padding: 10px 20px 20px;
-
-    p {
-      margin-bottom: 0;
-    }
-  }
 }
 
 .who-saved {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -19,7 +19,7 @@ $path: "/public/images/";
 }
 
 .not-running-notice {
-  border: 5px solid $govuk-blue;
+  border: 5px solid $grey-3;
   padding: 20px;
 }
 
@@ -56,9 +56,16 @@ table thead th {
   margin-bottom: -1px;
 }
 
-// .phase-tag-draft {
-//   background: $pink;
-// }
+.phase-tag-not-running {
+  background: $grey-3;
+  color: $black;
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+
+.phase-tag-draft {
+  background: $orange;
+}
 
 .phase-tag-published {
   background: $button-colour;
@@ -292,19 +299,15 @@ dl.aligned.course-part-tasks dd {
   }
 
   .subject-col {
-    width: 25%;
+    width: 40%;
   }
 
   .type-col {
-    width: 30%;
+    width: 40%;
   }
 
   .status-col {
     width: 20%;
-  }
-
-  .complete-col {
-    width: 25%;
   }
 
   .ucas-view-link {

--- a/app/routes.js
+++ b/app/routes.js
@@ -19,6 +19,11 @@ router.get('/about-your-organisation', function (req, res) {
   res.render('about-your-organisation', { errors: errors, justPublished: (req.query.publish && errors.length == 0) })
 })
 
+router.get('/about-your-organisation/edit', function (req, res) {
+  var errors = validateOrg(req.session.data);
+  res.render('about-your-organisation/edit', { errors: errors, justPublished: (req.query.publish && errors.length == 0) })
+})
+
 router.post('/about-your-organisation', function (req, res) {
   req.session.data['about-your-organisation-publish-state'] = 'draft';
   res.render('about-your-organisation', { showMessage: true, publishState : 'draft' })
@@ -326,7 +331,7 @@ function validateOrg(data) {
     errors.push({
       title: 'Give details about your organisation',
       id: `about-organisation`,
-      link: `/about-your-organisation#about-organisation`,
+      link: `/about-your-organisation/edit#about-organisation`,
       page: 'about-your-organisation'
     })
   }
@@ -335,7 +340,7 @@ function validateOrg(data) {
     errors.push({
       title: 'Give details about training with a disability',
       id: `training-with-a-disability`,
-      link: `/about-your-organisation#training-with-a-disability`,
+      link: `/about-your-organisation/edit#training-with-a-disability`,
       page: 'about-your-organisation'
     })
   }

--- a/app/views/about-your-organisation.html
+++ b/app/views/about-your-organisation.html
@@ -3,11 +3,17 @@
 {% block page_title %}{{ title }}{% endblock %}
 
 {% block content %}
-
 <main id="content" role="main">
   {% include "includes/phase_banner_beta.html" %}
 
-  {{ macros.orgHeading('About your organisation', message) }}
+  <div class="breadcrumbs">
+
+    <ol>
+      {% if value('multi-organisation') %}<li><a href="/">Organisations</a></li>{% endif %}
+      <li><a href="/">{{ data['training-provider-name']}}</a></li>
+    </ol>
+
+  </div>
 
   {% set message %}
     {% if showMessage %}
@@ -43,14 +49,14 @@
   </div>
   {% endif %}
 
-  <h2 class="heading-large">
-    {{ title }}
-  </h2>
+  {{ macros.orgHeading('About your organisation', message) }}
 
   <form action="/about-your-organisation" method="post">
     <div class="grid-row">
       <div class="column-two-thirds">
         <p>This information shows on all of your courses.</p>
+
+        <h2 class="heading-large">Training with you</h2>
 
         <p>This is your chance to tell applicants why they should choose to train with you. You could describe any advantages and special features of you as a training provider.</p>
 

--- a/app/views/about-your-organisation.html
+++ b/app/views/about-your-organisation.html
@@ -51,65 +51,53 @@
 
   {{ macros.orgHeading('About your organisation', message) }}
 
-  <form action="/about-your-organisation" method="post">
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        <p>This information shows on all of your courses.</p>
+  <div class="grid-row add-top-margin">
+    <div class="column-two-thirds">
+      <div class="course-parts course-parts--large">
+        <ul class="course-parts-items">
+          <li class="course-parts-item">
+            <h3 class="course-part-task">Contact details from UCAS</h3>
+            <div style="overflow: hidden; clear: left; margin-bottom: 30px;"></div>
+            <dl class="course-part-tasks aligned add-top-margin add-bottom-margin">
+              <dt>Training provider code:</dt>
+              <dd>{{ data['provider-code'] }}</dd>
+              <dt>Email:</dt>
+              <dd>{{ data['email'] }}</dd>
+              <dt>Telephone:</dt>
+              <dd>{{ data['telephone'] }}</dd>
+              <dt>Website:</dt>
+              <dd><a href="{{ data['website'] }}" style="padding: 0">{{ data['website'] }}</a></dd>
+              <dt>Address:</dt>
+              <dd>
+                {{ data['training-provider-name'] }}<br />
+                {{ data['address-line-1'] }}<br />
+                {{ data['town'] }}<br />
+                {{ data['postcode'] }}
+              </dd>
+            </dl>
+          </li>
+          <li class="course-parts-item">
+            <h3 class="course-part-task">About your organisation</h3>
+            <a class="course-part-task-action" href="/about-your-organisation/edit">Edit</a>
 
-        <h2 class="heading-large">Training with you</h2>
-
-        <p>This is your chance to tell applicants why they should choose to train with you. You could describe any advantages and special features of you as a training provider.</p>
-
-        <p>You must be specific and factual with any claims you make, and support them with evidence. For example:</p>
-
-        <ul class="list list-bullet">
-          <li>don’t say “our students are some of the happiest in the country”</li>
-          <li>do say “the Times Educational Supplement ranked our students as 4th happiest in the country”</li>
+            <dl class="course-part-tasks">
+              {{ macros.coursePart('about-organisation', 'About your organisation') }}
+              {% if not data['self_accrediting'] %}
+                {% for a in data['accreditors'] %}
+                  {{ macros.coursePart(a.slug + '-about-accrediting-provider', 'About ' + a.name + ' (optional)') }}
+                {% endfor %}
+              {% endif %}
+              {{ macros.coursePart('training-with-a-disability', 'Training with disabilities and other needs') }}
+            </dl>
+          </li>
         </ul>
-        {{ macros.textarea('about-organisation', 'Training with you', 14, '', 250, errors) }}
-
-        {% if not data['self_accrediting'] %}
-          {% if data['accreditors'].length > 1 %}
-            <h2 class="heading-large">
-              About your accredited providers
-            </h2>
-            <p>Describe advantages and special features of each accredited provider. You must be specific and factual with any claims you make, and support them with evidence.</p>
-          {% else %}
-            <h2 class="heading-large">
-              About your accredited provider
-            </h2>
-            <p>Describe advantages and special features of your accredited provider. You must be specific and factual with any claims you make, and support them with evidence.</p>
-          {% endif %}
-
-          {% for a in data['accreditors'] %}
-            {{ macros.textarea(a.slug + '-about-accrediting-provider', 'About ' + a.name + ' (optional)', 8, '', 100) }}
-          {% endfor %}
-        {% endif %}
-
-        <h3 class="heading-large remove-top-margin">Training with disabilities and other needs</h3>
-        <p>Say how you support candidates with disabilities and other needs. This could include candidates with:</p>
-
-        <ul class="list list-bullet">
-          <li>dyslexia</li>
-          <li>physical, hearing and visual impairments</li>
-          <li>mental health conditions</li>
-        </ul>
-        <p>If accessibility varies between locations, give details. It’s also useful to candidates to know how you’ve accommodated others with specific access needs in the past.</p>
-
-        {{ macros.textarea('training-with-a-disability', 'Training with disabilities and other needs', 14, '', 250, errors) }}
-      </div>
-      <div class="column-one-third">
-        {% set publishState = publishState or data['about-your-organisation-publish-state'] or 'new' %}
-        {{ macros.aboutYourOrgPublish(publishState, data['about-your-organisation-published-before'], '/publish/about-your-organisation') }}
       </div>
     </div>
-
-    <div class="add-double-bottom-margin">
-      <input type="submit" class="button" value="Save" />
+    <div class="column-one-third">
+      {% set publishState = publishState or data['about-your-organisation-publish-state'] or 'new' %}
+      {{ macros.aboutYourOrgPublish(publishState, data['about-your-organisation-published-before'], '/publish/about-your-organisation') }}
     </div>
-
-    <a href="/">Cancel changes</a>
-  </form>
+  </div>
 </main>
 
 {% endblock %}

--- a/app/views/about-your-organisation/edit.html
+++ b/app/views/about-your-organisation/edit.html
@@ -1,0 +1,72 @@
+{% extends "layout.html" %}
+{% set title = 'Edit ‘About your organisation’' %}
+{% block page_title %}{{ title }}{% endblock %}
+
+{% block content %}
+<main id="content" role="main">
+  {% include "includes/phase_banner_beta.html" %}
+<a href="/about-your-organisation" class="link-back">Back</a>
+
+<h1 class="heading-xlarge">
+  {{ title }}
+</h1>
+
+  <form action="/about-your-organisation" method="post">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <h2 class="heading-large remove-top-margin">About your organisation</h2>
+
+        <p>This is your chance to tell applicants why they should choose to train with you. You could describe any advantages and special features of you as a training provider.</p>
+
+        <p>You must be specific and factual with any claims you make, and support them with evidence. For example:</p>
+
+        <ul class="list list-bullet">
+          <li>don’t say “our students are some of the happiest in the country”</li>
+          <li>do say “the Times Educational Supplement ranked our students as 4th happiest in the country”</li>
+        </ul>
+        {{ macros.textarea('about-organisation', 'Training with you', 14, '', 250, errors) }}
+
+        {% if not data['self_accrediting'] %}
+          {% if data['accreditors'].length > 1 %}
+            <h2 class="heading-large">
+              About your accredited providers
+            </h2>
+            <p>Describe advantages and special features of each accredited provider. You must be specific and factual with any claims you make, and support them with evidence.</p>
+          {% else %}
+            <h2 class="heading-large">
+              About your accredited provider
+            </h2>
+            <p>Describe advantages and special features of your accredited provider. You must be specific and factual with any claims you make, and support them with evidence.</p>
+          {% endif %}
+
+          {% for a in data['accreditors'] %}
+            {{ macros.textarea(a.slug + '-about-accrediting-provider', 'About ' + a.name + ' (optional)', 8, '', 100) }}
+          {% endfor %}
+        {% endif %}
+
+        <h3 class="heading-large remove-top-margin">Training with disabilities and other needs</h3>
+        <p>Say how you support candidates with disabilities and other needs. This could include candidates with:</p>
+
+        <ul class="list list-bullet">
+          <li>dyslexia</li>
+          <li>physical, hearing and visual impairments</li>
+          <li>mental health conditions</li>
+        </ul>
+        <p>If accessibility varies between locations, give details. It’s also useful to candidates to know how you’ve accommodated others with specific access needs in the past.</p>
+
+        {{ macros.textarea('training-with-a-disability', 'Training with disabilities and other needs', 14, '', 250, errors) }}
+      </div>
+      <div class="column-one-third">
+        {{ macros.formattingBox() }}
+      </div>
+    </div>
+
+    <div class="add-double-bottom-margin">
+      <input type="submit" class="button" value="Save" />
+    </div>
+
+    <a href="/about-your-organisation">Cancel changes</a>
+  </form>
+</main>
+
+{% endblock %}

--- a/app/views/macros/macros.njk
+++ b/app/views/macros/macros.njk
@@ -91,11 +91,16 @@
 <div class="add-double-bottom-margin status-box">
   {% if state == 'draft' %}
     <div class="unpublished-changes">
-      <p><span class="bold">You have unpublished changes.</span></p>
-      <p class="who-saved add-top-margin">Last saved:<br />{{ today() }} by Jane Doe</p>
+      <span class="phase-tag phase-tag-draft add-bottom-margin">Draft</span>
+      <p>You have unpublished changes.</p>
+      <p class="add-top-margin">Last saved:<br />{{ today() }} by Jane Doe</p>
     </div>
+    <hr />
   {% endif %}
 
+  {% if state == 'published' %}
+    <span class="phase-tag phase-tag-published add-bottom-margin">Published</span>
+  {% endif %}
   {% if publishedBefore or state == 'published' %}
     <p>Last published:<br />{{ today() }} by Rita Cosca</p>
 
@@ -103,6 +108,7 @@
   {% endif %}
 
   {% if state == 'new' %}
+    <span class="phase-tag phase-tag-no-content add-bottom-margin">Empty</span>
     <p>You need to complete and publish this information.</p>
     <hr />
   {% endif %}
@@ -126,14 +132,24 @@
 {% macro coursePublish(state = 'new', publishedBefore = false, previewLink = '#', publishLink = '#') %}
 <div class="add-double-bottom-margin status-box">
   {% if state == 'draft' %}
-    <div class="unpublished-changes">
-      <p>You have unpublished changes.</p>
-      <p class="who-saved add-top-margin">Last saved:<br />{{ today() }} by Jane Doe</p>
-    </div>
+    <span class="phase-tag phase-tag-draft add-bottom-margin">Draft</span>
+    <p>You have unpublished changes.</p>
+    <p class="add-top-margin">Last saved:<br />{{ today() }} by Jane Doe</p>
+    <hr />
+  {% endif %}
+
+  {% if state == 'published' %}
+    <span class="phase-tag phase-tag-published add-bottom-margin">Draft</span>
   {% endif %}
 
   {% if publishedBefore or state == 'published' %}
     <p>Last published:<br />{{ today() }} by Rita Cosca</p>
+    <hr />
+  {% endif %}
+
+  {% if state == 'new' %}
+    <span class="phase-tag phase-tag-no-content add-bottom-margin">Empty</span>
+    <p>You need to complete and publish this information.</p>
     <hr />
   {% endif %}
 

--- a/app/views/macros/macros.njk
+++ b/app/views/macros/macros.njk
@@ -150,46 +150,11 @@
 {% endmacro %}
 
 {% macro orgHeading(activeTab, message = '') %}
-<div class="breadcrumbs">
-  {% if value('multi-organisation') %}
-  <ol>
-    <li><a href="/">Organisations</a></li>
-  </ol>
-  {% endif %}
-</div>
-
 {{ message | safe }}
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-xlarge">
-      {{ value('training-provider-name') }}
-    </h1>
-  </div>
-</div>
-
-{% set tabs = [
-    {
-      text: 'Courses',
-      href: '/'
-    },
-    {
-      text: 'About your organisation',
-      href: '/about-your-organisation'
-    },
-    {
-      text: 'Request access for someone else',
-      href: '/request-access'
-    }
-  ] %}
-
-<ul class="tabs">
-  {% for tab in tabs %}
-    <li {% if activeTab == tab.text %}class="active"{% endif %}>
-      <a href="{{ tab.href }}">{{ tab.text }}</a>
-    </li>
-  {% endfor %}
-</ul>
+<h1 class="heading-xlarge">
+  {{ activeTab }}
+</h1>
 {% endmacro %}
 
 {#

--- a/app/views/macros/macros.njk
+++ b/app/views/macros/macros.njk
@@ -74,6 +74,9 @@
     <div class="js-cant-copy" style="display: none">
       <p>When you’ve added content to this page, you can copy it to other courses</p>
     </div>
+    <hr />
+
+    {{ formatting() }}
   </div>
 </form>
 {% endmacro %}

--- a/app/views/macros/macros.njk
+++ b/app/views/macros/macros.njk
@@ -78,6 +78,12 @@
 </form>
 {% endmacro %}
 
+{% macro formattingBox() %}
+<div class="add-double-bottom-margin status-box">
+  {{ formatting() }}
+</div>
+{% endmacro %}
+
 {% macro aboutYourOrgPublish(state = 'new', publishedBefore = false, publishLink = '#') %}
 <div class="add-double-bottom-margin status-box">
   {% if state == 'draft' %}
@@ -89,7 +95,8 @@
 
   {% if publishedBefore or state == 'published' %}
     <p>Last published:<br />{{ today() }} by Rita Cosca</p>
-    <hr />
+
+    {% if state == 'draft' %}<hr />{% endif %}
   {% endif %}
 
   {% if state == 'new' %}
@@ -109,10 +116,7 @@
     <p>
       <a href="{{ publishLink }}" class="button">Publish</a>
     </p>
-    <hr />
   {% endif %}
-
-  {{ formatting() }}
 </div>
 {% endmacro %}
 

--- a/app/views/organisation.html
+++ b/app/views/organisation.html
@@ -47,13 +47,12 @@
       </h3>
     {% endif %}
     <div class="body-text">
-      <table class="ucas-info-table table-small">
+      <table class="ucas-info-table">
         <thead>
           <tr>
-            <th class="subject-col" style="width: 30%">Course</th>
+            <th class="subject-col">Course</th>
             <th class="type-col">Type</th>
-            <th class="status-col">Status</th>
-            <th class="complete-col">Course content</th>
+            <th class="status-col">State</th>
           </tr>
         </thead>
         <tbody>
@@ -67,17 +66,9 @@
                   {% else %}
                     <a href="/course-not-running/{{ accrediting.slug }}/{{ course.programmeCode }}">{{ course.name }} ({{ course.programmeCode }})</a>
                   {% endif %}
+                  </span>
                 </td>
                 <td>{{ course.options }}</td>
-                <td>{% if loop.index == 2 %}
-                      New – not yet running
-                    {% elseif loop.index == 7 %}
-                      Not running
-                    {% elseif loop.index == 4 %}
-                      Not running
-                    {% else %}
-                      Running
-                    {% endif %}</td>
                 <td>
                   {% if (loop.index != 2 and loop.index != 4 and loop.index != 7) %}
                     {% if data[course.programmeCode + '-publish-state'] == 'draft' %}
@@ -87,6 +78,10 @@
                     {% else %}
                       <span class="phase-tag phase-tag-small phase-tag-no-content">Empty</span>
                     {% endif %}
+                  {% elseif loop.index == 2 %}
+                    <span class="phase-tag phase-tag-small phase-tag-not-running">New – not yet running</span>
+                  {% else %}
+                    <span class="phase-tag phase-tag-small phase-tag-not-running">Not running</span>
                   {% endif %}
                 </td>
               </tr>

--- a/app/views/organisation.html
+++ b/app/views/organisation.html
@@ -5,7 +5,33 @@
 
 <main id="content" role="main">
   {% include "includes/phase_banner_beta.html" %}
-  {{ macros.orgHeading('Courses') }}
+  <div class="breadcrumbs">
+    <ol>
+      {% if value('multi-organisation') %}<li><a href="/">Organisations</a></li>{% endif %}
+    </ol>
+  </div>
+
+  <h1 class="heading-xlarge">{{ data['training-provider-name'] }}</h1>
+
+  <h2 class="heading-large">About your organisation</h2>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <dl class="course-part-tasks remove-top-margin">
+        {{ macros.coursePart('about-your-organisation', 'About your organisation') }}
+        {% if not data['self_accrediting'] %}
+          {% for a in data['accreditors'] %}
+            {{ macros.coursePart(a.slug + '-about-accrediting-provider', 'About ' + a.name + ' (optional)') }}
+          {% endfor %}
+        {% endif %}
+        {{ macros.coursePart('training-with-a-disability', 'Training with disabilities and other needs') }}
+      </dl>
+
+      <p class="add-top-margin">
+        <a href="/about-your-organisation">Edit and publish organisation information</a>
+      </p>
+    </div>
+  </div>
+  <hr />
 
   <h2 class="heading-large">
     Courses
@@ -69,6 +95,13 @@
       </table>
     </div>
   {% endfor %}
+  <hr />
+
+  <h2 class="heading-large">Request access for someone</h2>
+  <p>You can request a DfE Sign-in account for others who manage your courses.</p>
+  <p>
+    <a href="/request-access">Request access for someone</a>
+  </p>
 </main>
 
 {% endblock %}

--- a/app/views/organisation.html
+++ b/app/views/organisation.html
@@ -20,7 +20,7 @@
   <h2 class="heading-large remove-top-margin">About your organisation</h2>
   <div class="grid-row">
     <div class="column-two-thirds">
-      <p>Your organisation information and contact details display on every course. They are edited and published separately to course information.</p>
+      <p>Your organisation information and contact details will show on every course. They are edited and published separately from course information.</p>
       <p>
         {% if data['about-your-organisation-publish-state'] == 'draft' %}
           <span class="phase-tag phase-tag-small phase-tag-draft">Draft</span>

--- a/app/views/organisation.html
+++ b/app/views/organisation.html
@@ -20,18 +20,16 @@
   <h2 class="heading-large remove-top-margin">About your organisation</h2>
   <div class="grid-row">
     <div class="column-two-thirds">
-      <dl class="course-part-tasks remove-top-margin">
-        {{ macros.coursePart('about-organisation', 'About your organisation') }}
-        {% if not data['self_accrediting'] %}
-          {% for a in data['accreditors'] %}
-            {{ macros.coursePart(a.slug + '-about-accrediting-provider', 'About ' + a.name + ' (optional)') }}
-          {% endfor %}
+      <p>Your organisation information and contact details display on every course. They are edited and published separately to course information.</p>
+      <p>
+        {% if data['about-your-organisation-publish-state'] == 'draft' %}
+          <span class="phase-tag phase-tag-small phase-tag-draft">Draft</span>
+        {% elseif data['about-your-organisation-publish-state'] == 'published' %}
+          <span class="phase-tag phase-tag-small phase-tag-published">Published</span>
+        {% else %}
+          <span class="phase-tag phase-tag-small phase-tag-no-content">Empty</span>
         {% endif %}
-        {{ macros.coursePart('training-with-a-disability', 'Training with disabilities and other needs') }}
-      </dl>
-
-      <p class="add-top-margin">
-        <a href="/about-your-organisation">Edit and publish organisation information</a>
+        <a href="/about-your-organisation">Edit your organisation information</a>
       </p>
     </div>
   </div>

--- a/app/views/organisation.html
+++ b/app/views/organisation.html
@@ -44,7 +44,7 @@
   {% for accrediting in data['accreditors'] %}
     {% if data['accreditors'][0]['name'] != data['training-provider-name'] %}
       <h3 class="heading-medium">
-        <span style="color: #777; font-weight: normal">Accrediting provider</span><br />
+        <span style="color: #777; font-weight: normal">Accredited provider</span><br />
         {{ accrediting.name }}
       </h3>
     {% endif %}

--- a/app/views/organisation.html
+++ b/app/views/organisation.html
@@ -11,9 +11,13 @@
     </ol>
   </div>
 
-  <h1 class="heading-xlarge">{{ data['training-provider-name'] }}</h1>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-xlarge">{{ data['training-provider-name'] }}</h1>
+    </div>
+  </div>
 
-  <h2 class="heading-large">About your organisation</h2>
+  <h2 class="heading-large remove-top-margin">About your organisation</h2>
   <div class="grid-row">
     <div class="column-two-thirds">
       <dl class="course-part-tasks remove-top-margin">

--- a/app/views/organisation.html
+++ b/app/views/organisation.html
@@ -17,7 +17,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <dl class="course-part-tasks remove-top-margin">
-        {{ macros.coursePart('about-your-organisation', 'About your organisation') }}
+        {{ macros.coursePart('about-organisation', 'About your organisation') }}
         {% if not data['self_accrediting'] %}
           {% for a in data['accreditors'] %}
             {{ macros.coursePart(a.slug + '-about-accrediting-provider', 'About ' + a.name + ' (optional)') }}

--- a/app/views/request-access.html
+++ b/app/views/request-access.html
@@ -6,6 +6,13 @@
 <main id="content" role="main">
   {% include "includes/phase_banner_beta.html" %}
 
+  <div class="breadcrumbs">
+    <ol>
+      {% if value('multi-organisation') %}<li><a href="/">Organisations</a></li>{% endif %}
+      <li><a href="/">{{ data['training-provider-name']}}</a></li>
+    </ol>
+  </div>
+
   {% set message %}
     {% if showMessage %}
       <div class="success-summary" role="alert" aria-labelledby="success-summary-heading-example-1" tabindex="-1" style="margin-bottom: 60px">
@@ -19,11 +26,7 @@
     {% endif %}
   {% endset %}
 
-  {{ macros.orgHeading('Request access for someone else', message) }}
-
-  <h2 class="heading-large">
-    Request access for someone else
-  </h2>
+  {{ macros.orgHeading('Request access for someone', message) }}
 
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/generate.rb
+++ b/generate.rb
@@ -5,7 +5,7 @@ require 'json'
 
 file = File.read('courses-clean.json')
 data = JSON.parse(file)
-provider = 'Bromley Schools Collegiate'
+provider = 'Angel Islington Teaching School Alliance'
 courses = data.select {|c| c['provider'] == provider }
 
 prototype_data = {
@@ -18,7 +18,7 @@ prototype_data = {
   'postcode': 'SW1 1AA',
   'telephone': '0208 123 4567',
   'email': 'someemail@not-an-email.com',
-  'website': 'https://www.bscteach.co.uk/',
+  'website': 'http://www.egaschool.co.uk/244/the-angel-islington-teaching-school-alliance',
   'templates': []
 }
 

--- a/lib/prototype_data.json
+++ b/lib/prototype_data.json
@@ -1,34 +1,34 @@
 {
   "multi-organisation": false,
-  "training-provider-name": "Bromley Schools Collegiate",
-  "provider-code-name": "BROM",
-  "provider-code": "B91",
+  "training-provider-name": "Angel Islington Teaching School Alliance",
+  "provider-code-name": "A2602",
+  "provider-code": "2BZ",
   "address-line-1": "123 Baker Street",
   "town": "London",
   "postcode": "SW1 1AA",
   "telephone": "0208 123 4567",
   "email": "someemail@not-an-email.com",
-  "website": "https://www.bscteach.co.uk/",
+  "website": "http://www.egaschool.co.uk/244/the-angel-islington-teaching-school-alliance",
   "templates": [
 
   ],
   "ucasCourses": [
     {
       "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
-      "subjects": "Computer studies, Secondary",
+      "accrediting": "UCL, University College London (University of London",
+      "subjects": "Biology, Science, Secondary",
       "ageRange": "Secondary (11+ years)",
-      "name": "Computer Science",
-      "slug": "computer-science",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "IX99",
+      "name": "Biology",
+      "slug": "biology",
+      "route": "School Direct training programme",
+      "qualifications": "QTS, Postgraduate",
+      "providerCode": "2BZ",
+      "programmeCode": "2YCF",
       "schools": [
         {
           "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
+          "address": "Donegal Street, Islington, London, N1 9QG",
+          "code": "-"
         }
       ],
       "options": [
@@ -37,20 +37,20 @@
     },
     {
       "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
-      "subjects": "Drama and theatre studies, Secondary",
+      "accrediting": "UCL, University College London (University of London",
+      "subjects": "Chemistry, Science, Secondary",
       "ageRange": "Secondary (11+ years)",
-      "name": "Drama",
-      "slug": "drama",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "2YDF",
+      "name": "Chemistry",
+      "slug": "chemistry",
+      "route": "School Direct training programme",
+      "qualifications": "QTS, Postgraduate",
+      "providerCode": "2BZ",
+      "programmeCode": "2YN3",
       "schools": [
         {
           "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
+          "address": "Donegal Street, Islington, London, N1 9QG",
+          "code": "-"
         }
       ],
       "options": [
@@ -59,20 +59,20 @@
     },
     {
       "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
+      "accrediting": "UCL, University College London (University of London",
       "subjects": "English, Secondary",
       "ageRange": "Secondary (11+ years)",
       "name": "English",
       "slug": "english",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "Q3X1",
+      "route": "School Direct training programme",
+      "qualifications": "QTS, Postgraduate",
+      "providerCode": "2BZ",
+      "programmeCode": "2YNS",
       "schools": [
         {
           "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
+          "address": "Donegal Street, Islington, London, N1 9QG",
+          "code": "-"
         }
       ],
       "options": [
@@ -81,20 +81,20 @@
     },
     {
       "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
+      "accrediting": "UCL, University College London (University of London",
       "subjects": "Geography, Secondary",
       "ageRange": "Secondary (11+ years)",
       "name": "Geography",
       "slug": "geography",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "2YDH",
+      "route": "School Direct training programme",
+      "qualifications": "QTS, Postgraduate",
+      "providerCode": "2BZ",
+      "programmeCode": "37KD",
       "schools": [
         {
           "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
+          "address": "Donegal Street, Islington, London, N1 9QG",
+          "code": "-"
         }
       ],
       "options": [
@@ -103,42 +103,20 @@
     },
     {
       "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
-      "subjects": "History, Secondary",
-      "ageRange": "Secondary (11+ years)",
-      "name": "History",
-      "slug": "history",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "V1X1",
-      "schools": [
-        {
-          "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
-        }
-      ],
-      "options": [
-        "PGCE with QTS full time"
-      ]
-    },
-    {
-      "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
+      "accrediting": "UCL, University College London (University of London",
       "subjects": "Mathematics, Secondary",
       "ageRange": "Secondary (11+ years)",
       "name": "Mathematics",
       "slug": "mathematics",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "G1X1",
+      "route": "School Direct training programme",
+      "qualifications": "QTS, Postgraduate",
+      "providerCode": "2BZ",
+      "programmeCode": "2YNR",
       "schools": [
         {
           "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
+          "address": "Donegal Street, Islington, London, N1 9QG",
+          "code": "-"
         }
       ],
       "options": [
@@ -147,20 +125,20 @@
     },
     {
       "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
+      "accrediting": "UCL, University College London (University of London",
       "subjects": "Languages, Secondary",
       "ageRange": "Secondary (11+ years)",
       "name": "Modern Languages",
       "slug": "modern-languages",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "2YDJ",
+      "route": "School Direct training programme",
+      "qualifications": "QTS, Postgraduate",
+      "providerCode": "2BZ",
+      "programmeCode": "37KG",
       "schools": [
         {
           "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
+          "address": "Donegal Street, Islington, London, N1 9QG",
+          "code": "-"
         }
       ],
       "options": [
@@ -169,64 +147,20 @@
     },
     {
       "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
-      "subjects": "Music, Secondary",
-      "ageRange": "Secondary (11+ years)",
-      "name": "Music",
-      "slug": "music",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "2YDK",
-      "schools": [
-        {
-          "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
-        }
-      ],
-      "options": [
-        "PGCE with QTS full time"
-      ]
-    },
-    {
-      "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
-      "subjects": "Physical education, Secondary",
-      "ageRange": "Secondary (11+ years)",
-      "name": "Physical Education",
-      "slug": "physical-education",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "2YDL",
-      "schools": [
-        {
-          "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
-        }
-      ],
-      "options": [
-        "PGCE with QTS full time"
-      ]
-    },
-    {
-      "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
+      "accrediting": "UCL, University College London (University of London",
       "subjects": "Physics, Science, Secondary",
       "ageRange": "Secondary (11+ years)",
       "name": "Physics",
       "slug": "physics",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "F3X1",
+      "route": "School Direct training programme",
+      "qualifications": "QTS, Postgraduate",
+      "providerCode": "2BZ",
+      "programmeCode": "2YNQ",
       "schools": [
         {
           "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
+          "address": "Donegal Street, Islington, London, N1 9QG",
+          "code": "-"
         }
       ],
       "options": [
@@ -235,42 +169,20 @@
     },
     {
       "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
+      "accrediting": "UCL, University College London (University of London",
       "subjects": "Primary",
       "ageRange": "Primary (c3 - 11/12 years)",
-      "name": "Primary (5-11)",
-      "slug": "primary-5-11",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "X105",
+      "name": "Primary",
+      "slug": "primary",
+      "route": "School Direct training programme",
+      "qualifications": "QTS, Postgraduate",
+      "providerCode": "2BZ",
+      "programmeCode": "2YNV",
       "schools": [
         {
           "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
-        }
-      ],
-      "options": [
-        "PGCE with QTS full time"
-      ]
-    },
-    {
-      "regions": "London",
-      "accrediting": "Bromley Schools Collegiate",
-      "subjects": "Religious education, Secondary",
-      "ageRange": "Secondary (11+ years)",
-      "name": "Religious Education",
-      "slug": "religious-education",
-      "route": "SCITT (School Centred Initial Teacher Training) programme",
-      "qualifications": "QTS, Postgraduate, Professional",
-      "providerCode": "B91",
-      "programmeCode": "33YX",
-      "schools": [
-        {
-          "name": "Main Site",
-          "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-          "code": ""
+          "address": "Donegal Street, Islington, London, N1 9QG",
+          "code": "-"
         }
       ],
       "options": [
@@ -281,22 +193,22 @@
   "schools": [
     {
       "name": "Main Site",
-      "address": "Beaverwood School, Beaverwood Road, Chislehurst, Kent, BR7 6HE",
-      "code": ""
+      "address": "Donegal Street, Islington, London, N1 9QG",
+      "code": "-"
     }
   ],
   "accreditors": [
     {
-      "name": "Bromley Schools Collegiate",
-      "slug": "bromley-schools-collegiate",
+      "name": "UCL, University College London (University of London",
+      "slug": "ucl-university-college-london-university-of-london",
       "subjects": [
         {
-          "name": "Computer Science",
-          "slug": "computer-science"
+          "name": "Biology",
+          "slug": "biology"
         },
         {
-          "name": "Drama",
-          "slug": "drama"
+          "name": "Chemistry",
+          "slug": "chemistry"
         },
         {
           "name": "English",
@@ -307,10 +219,6 @@
           "slug": "geography"
         },
         {
-          "name": "History",
-          "slug": "history"
-        },
-        {
           "name": "Mathematics",
           "slug": "mathematics"
         },
@@ -319,37 +227,25 @@
           "slug": "modern-languages"
         },
         {
-          "name": "Music",
-          "slug": "music"
-        },
-        {
-          "name": "Physical Education",
-          "slug": "physical-education"
-        },
-        {
           "name": "Physics",
           "slug": "physics"
         },
         {
-          "name": "Primary (5-11)",
-          "slug": "primary-5-11"
-        },
-        {
-          "name": "Religious Education",
-          "slug": "religious-education"
+          "name": "Primary",
+          "slug": "primary"
         }
       ]
     }
   ],
-  "self_accrediting": true,
+  "self_accrediting": false,
   "subjects": [
     {
-      "name": "Computer Science",
-      "slug": "computer-science"
+      "name": "Biology",
+      "slug": "biology"
     },
     {
-      "name": "Drama",
-      "slug": "drama"
+      "name": "Chemistry",
+      "slug": "chemistry"
     },
     {
       "name": "English",
@@ -360,10 +256,6 @@
       "slug": "geography"
     },
     {
-      "name": "History",
-      "slug": "history"
-    },
-    {
       "name": "Mathematics",
       "slug": "mathematics"
     },
@@ -372,33 +264,21 @@
       "slug": "modern-languages"
     },
     {
-      "name": "Music",
-      "slug": "music"
-    },
-    {
-      "name": "Physical Education",
-      "slug": "physical-education"
-    },
-    {
       "name": "Physics",
       "slug": "physics"
     },
     {
-      "name": "Primary (5-11)",
-      "slug": "primary-5-11"
-    },
-    {
-      "name": "Religious Education",
-      "slug": "religious-education"
+      "name": "Primary",
+      "slug": "primary"
     }
   ],
   "folded_courses": {
-    "Bromley Schools Collegiate": [
+    "UCL, University College London (University of London": [
       {
-        "name": "Computer Science",
+        "name": "Biology",
         "courses": 1,
         "accrediting": [
-          "Bromley Schools Collegiate"
+          "UCL, University College London (University of London"
         ],
         "applicationsOpen": [
           "26 Oct 2017"
@@ -416,10 +296,10 @@
         }
       },
       {
-        "name": "Drama",
+        "name": "Chemistry",
         "courses": 1,
         "accrediting": [
-          "Bromley Schools Collegiate"
+          "UCL, University College London (University of London"
         ],
         "applicationsOpen": [
           "26 Oct 2017"
@@ -440,7 +320,7 @@
         "name": "English",
         "courses": 1,
         "accrediting": [
-          "Bromley Schools Collegiate"
+          "UCL, University College London (University of London"
         ],
         "applicationsOpen": [
           "26 Oct 2017"
@@ -461,28 +341,7 @@
         "name": "Geography",
         "courses": 1,
         "accrediting": [
-          "Bromley Schools Collegiate"
-        ],
-        "applicationsOpen": [
-          "26 Oct 2017"
-        ],
-        "schoolsWithVacancies": [
-          "Main Site"
-        ],
-        "options": [
-          "PGCE with QTS full time"
-        ],
-        "flags": {
-          "partTime": false,
-          "salary": false,
-          "qualifications": false
-        }
-      },
-      {
-        "name": "History",
-        "courses": 1,
-        "accrediting": [
-          "Bromley Schools Collegiate"
+          "UCL, University College London (University of London"
         ],
         "applicationsOpen": [
           "26 Oct 2017"
@@ -503,7 +362,7 @@
         "name": "Mathematics",
         "courses": 1,
         "accrediting": [
-          "Bromley Schools Collegiate"
+          "UCL, University College London (University of London"
         ],
         "applicationsOpen": [
           "26 Oct 2017"
@@ -524,49 +383,7 @@
         "name": "Modern Languages",
         "courses": 1,
         "accrediting": [
-          "Bromley Schools Collegiate"
-        ],
-        "applicationsOpen": [
-          "26 Oct 2017"
-        ],
-        "schoolsWithVacancies": [
-          "Main Site"
-        ],
-        "options": [
-          "PGCE with QTS full time"
-        ],
-        "flags": {
-          "partTime": false,
-          "salary": false,
-          "qualifications": false
-        }
-      },
-      {
-        "name": "Music",
-        "courses": 1,
-        "accrediting": [
-          "Bromley Schools Collegiate"
-        ],
-        "applicationsOpen": [
-          "26 Oct 2017"
-        ],
-        "schoolsWithVacancies": [
-          "Main Site"
-        ],
-        "options": [
-          "PGCE with QTS full time"
-        ],
-        "flags": {
-          "partTime": false,
-          "salary": false,
-          "qualifications": false
-        }
-      },
-      {
-        "name": "Physical Education",
-        "courses": 1,
-        "accrediting": [
-          "Bromley Schools Collegiate"
+          "UCL, University College London (University of London"
         ],
         "applicationsOpen": [
           "26 Oct 2017"
@@ -587,7 +404,7 @@
         "name": "Physics",
         "courses": 1,
         "accrediting": [
-          "Bromley Schools Collegiate"
+          "UCL, University College London (University of London"
         ],
         "applicationsOpen": [
           "26 Oct 2017"
@@ -605,31 +422,10 @@
         }
       },
       {
-        "name": "Primary (5-11)",
+        "name": "Primary",
         "courses": 1,
         "accrediting": [
-          "Bromley Schools Collegiate"
-        ],
-        "applicationsOpen": [
-          "26 Oct 2017"
-        ],
-        "schoolsWithVacancies": [
-          "Main Site"
-        ],
-        "options": [
-          "PGCE with QTS full time"
-        ],
-        "flags": {
-          "partTime": false,
-          "salary": false,
-          "qualifications": false
-        }
-      },
-      {
-        "name": "Religious Education",
-        "courses": 1,
-        "accrediting": [
-          "Bromley Schools Collegiate"
+          "UCL, University College London (University of London"
         ],
         "applicationsOpen": [
           "26 Oct 2017"


### PR DESCRIPTION
* Remove tabs from pages
* Put link to about your org on main body to make it more obvious and "in flow"
* Move request access down
* Make draft status orange to better represent incomplete state
* Represent statuses on the course and org pages